### PR TITLE
Enable todo warnings in analyzer

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,8 +2,8 @@ analyzer:
   strong-mode:
     implicit-casts: false
   #    implicit-dynamic: false
-  #  errors:
-  #    todo: warning
+  errors:
+    todo: warning
   exclude:
     - lib/l10n/messages_*.dart
     - lib/generated/**


### PR DESCRIPTION
Enabled "todo" warnings in the Dart static analyzer by uncommenting the relevant configuration in `analysis_options.yaml`. Verified that `dart analyze` now correctly reports TODO comments as warnings.

---
*PR created automatically by Jules for task [16497521495629927312](https://jules.google.com/task/16497521495629927312) started by @pasaneramusugoda*