### PR TITLE
🧪 [testing improvement] Unit tests for getNextDate in ViewModel

### DIFF
--- a/test/date_time_picker_view_model_test.dart
+++ b/test/date_time_picker_view_model_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:date_time_picker_widget/src/date_time_picker_view_model.dart';
+import 'package:date_time_picker_widget/src/date_time_picker_type.dart';
+
+void main() {
+  group('DateTimePickerViewModel - getNextDate', () {
+    final startDate = DateTime(2024, 1, 1);
+    late DateTimePickerViewModel viewModel;
+
+    setUp(() {
+      viewModel = DateTimePickerViewModel(
+        null, // initialSelectedDate
+        (_) {}, // onDateChanged
+        (_) {}, // onTimeChanged
+        startDate, // startDate
+        null, // endDate
+        null, // startTime
+        null, // endTime
+        const Duration(minutes: 30), // timeInterval
+        false, // is24h
+        DateTimePickerType.Both, // type
+        '', // timeOutOfRangeError
+        '', // datePickerTitle
+        '', // timePickerTitle
+        null, // customStringWeekdays
+        1, // numberOfWeeksToDisplay
+        null, // locale
+      );
+    });
+
+    test('getNextDate(0) should return startDate', () {
+      expect(viewModel.getNextDate(0), startDate);
+    });
+
+    test('getNextDate(1) should return the next day', () {
+      expect(viewModel.getNextDate(1), startDate.add(const Duration(days: 1)));
+    });
+
+    test('getNextDate(7) should return one week later', () {
+      expect(viewModel.getNextDate(7), startDate.add(const Duration(days: 7)));
+    });
+
+    test('getNextDate(-1) should return the previous day', () {
+      expect(
+        viewModel.getNextDate(-1),
+        startDate.subtract(const Duration(days: 1)),
+      );
+    });
+  });
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the lack of unit tests for the `getNextDate` utility method in `DateTimePickerViewModel`.
📊 **Coverage:** The new tests in `test/date_time_picker_view_model_test.dart` cover:
- `getNextDate(0)`: returns the expected start date.
- `getNextDate(1)`: returns the next day.
- `getNextDate(7)`: returns seven days after the start date.
- `getNextDate(-1)`: returns the day before the start date.
✨ **Result:** Improved test coverage and reliability for date-based calculations in the ViewModel. Verified logic using a standalone Dart script due to environment timeouts with standard flutter test.

---
*PR created automatically by Jules for task [7033273065027854983](https://jules.google.com/task/7033273065027854983) started by @pasaneramusugoda*