### PR TITLE
Enable todo warnings in analyzer

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,8 +2,8 @@ analyzer:
   strong-mode:
     implicit-casts: false
   #    implicit-dynamic: false
-  #  errors:
-  #    todo: warning
+  errors:
+    todo: warning
   exclude:
     - lib/l10n/messages_*.dart
     - lib/generated/**


### PR DESCRIPTION
This change enables 'todo' warnings in the analyzer by uncommenting the relevant lines in `analysis_options.yaml`. I verified the change by running `dart analyze` and confirming that it correctly identifies TODO comments as warnings. I also ensured that no unnecessary formatting changes were included in this submission.

---
*PR created automatically by Jules for task [4253832435631558386](https://jules.google.com/task/4253832435631558386) started by @pasaneramusugoda*