### PR TITLE
Enable todo warnings

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,8 +2,8 @@ analyzer:
   strong-mode:
     implicit-casts: false
   #    implicit-dynamic: false
-  #  errors:
-  #    todo: warning
+  errors:
+    todo: warning
   exclude:
     - lib/l10n/messages_*.dart
     - lib/generated/**


### PR DESCRIPTION
Enabled TODO warnings in the analyzer configuration by uncommenting the relevant lines in `analysis_options.yaml`. Verified the change using `flutter analyze --no-pub --verbose` with a temporary TODO comment, which was correctly flagged. Cleaned up all diagnostic files before submission. `flutter test` was skipped due to environment timeouts, which is a known issue for this repository.

---
*PR created automatically by Jules for task [2756186459812814595](https://jules.google.com/task/2756186459812814595) started by @pasaneramusugoda*